### PR TITLE
Optional-fields-173

### DIFF
--- a/server/src/modules/community-event/serializer.ts
+++ b/server/src/modules/community-event/serializer.ts
@@ -28,18 +28,34 @@ export default {
   updateRequest(
     requestBody: z.infer<typeof updateCommunityEventReq>['body'],
   ): Prisma.CommunityEventUpdateInput {
+
+    /* Make sure we are not adding any of the relationships if value is not set */
+    let communityEventRelationships = {};
+    if (requestBody.organizerUUID) {
+      communityEventRelationships = {
+        ...communityEventRelationships,
+        organizer: {
+          connect: {
+            id: requestBody.organizerUUID,
+          },
+        },
+      };
+    }
+
+    if (requestBody.eventTypeUUID) {
+      communityEventRelationships = {
+        ...communityEventRelationships,
+        eventType: {
+          connect: {
+            id: requestBody.eventTypeUUID,
+          },
+        },
+      };
+    }
+
     const result = {
       ...requestBody,
-      organizer: {
-        connect: {
-          id: requestBody.organizerUUID,
-        },
-      },
-      eventType: {
-        connect: {
-          id: requestBody.eventTypeUUID,
-        },
-      },
+      ...communityEventRelationships,
     };
     delete result.organizerUUID;
     delete result.eventTypeUUID;

--- a/server/src/modules/community-event/validations.ts
+++ b/server/src/modules/community-event/validations.ts
@@ -29,8 +29,8 @@ export const updateCommunityEventReq = z.object({
     id: z.string().uuid(),
   }),
   body: z.object({
-    organizerUUID: z.string().uuid().optional(),
-    eventTypeUUID: z.string().uuid().optional(),
+    organizerUUID: z.string().uuid().optional().or(z.literal('')),
+    eventTypeUUID: z.string().uuid().optional().or(z.literal('')),
     ideaConfirmed: z.boolean().optional(),
     date: z.coerce.date().optional(),
     inPersonEvent: z.boolean().optional(),

--- a/web/src/Components/EditEvent/EventForm.tsx
+++ b/web/src/Components/EditEvent/EventForm.tsx
@@ -43,8 +43,8 @@ const schemaPatterns = {
 
 const validationSchema: ZodType<CommunityEventForm> = z.object({
   date: z.string(),
-  eventTypeUUID: z.string().uuid().optional(),
-  organizerUUID: z.string().uuid().optional(),
+  eventTypeUUID: z.string().uuid().optional().or(z.literal('')),
+  organizerUUID: z.string().uuid().optional().or(z.literal('')),
   venue: schemaPatterns.optionalString,
   venueContactName: schemaPatterns.optionalString,
   venueContactEmail: schemaPatterns.optionalEmail,
@@ -156,6 +156,12 @@ const EventForm = ({ communityEvent }: Props) => {
       volunteersNeeded: data.volunteersNeeded,
       volunteerRequestsSent: data.volunteerRequestsSent,
     };
+
+    /* remove organizer UUID if not set */
+    if (!event.organizerUUID) {
+      event.organizerUUID = undefined;
+    }
+
     const submittedEvent = await eventService.updateEvent(eventId, event);
 
     if (submittedEvent) {

--- a/web/src/Components/EditEvent/EventForm.tsx
+++ b/web/src/Components/EditEvent/EventForm.tsx
@@ -157,11 +157,6 @@ const EventForm = ({ communityEvent }: Props) => {
       volunteerRequestsSent: data.volunteerRequestsSent,
     };
 
-    /* remove organizer UUID if not set */
-    if (!event.organizerUUID) {
-      event.organizerUUID = undefined;
-    }
-
     const submittedEvent = await eventService.updateEvent(eventId, event);
 
     if (submittedEvent) {


### PR DESCRIPTION
This was a similar issue to a problem I had allowing an optional email field.  .or(z.literal('')) will let Zod handle the empty string without thinking its an error.

Once solved the server was thowing an error due to the missing UUID field that was needed to create  a relationship.  Fixed by added a conditional to insert the relationships for both connections only if a UUID exists.